### PR TITLE
Updated params.pp to handle CentOS 7 package name

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,10 +16,13 @@ class sysctl::params {
 
   ### Application related parameters
 
-  $package = $::operatingsystem ? {
-    default => 'procps',
-  }
-
+#package name fix for centos 7
+  if $::operatingsystem == 'CentOS' and $::lsbmajdistrelease == '7' {
+    $package = 'procps-ng'
+  } else {
+    $package = 'procps'
+  } 
+  
   $config_dir = $::operatingsystem ? {
     default => '/etc/sysctl.d',
   }


### PR DESCRIPTION
procps package name is updated for CentOS 7 , so i added this change and tested. I am not so much of an expert in coding, but this change is working for my environment. Could you please take a look ?